### PR TITLE
Avoid error with bad gpx and make file extension more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-gpx/*.gpx
+gpx/
 tiles/
 venv/
 *.png

--- a/strava_local_heatmap.py
+++ b/strava_local_heatmap.py
@@ -68,9 +68,10 @@ def gaussian_filter(image: np.ndarray, sigma: float) -> np.ndarray:
 
 def main(args: Namespace) -> None:
     # read GPX trackpoints
-    gpx_files = glob.glob('{}/{}'.format(args.dir,
-                                         args.filter))
+    all_files = glob.glob(os.path.join(args.dir, '*.*'))
 
+    gpx_files = [file for file in all_files if file.lower().endswith(args.filter[1:].lower())]
+    
     if not gpx_files:
         exit('ERROR no data matching {}/{}'.format(args.dir,
                                                    args.filter))
@@ -94,8 +95,9 @@ def main(args: Namespace) -> None:
                             if '<trkpt' in line:
                                 l = line.split('"')
 
-                                lat_lon_data.append([float(l[1]),
-                                                     float(l[3])])
+                                if len(l) > 3: 
+                                    lat_lon_data.append([float(l[1]),
+                                                        float(l[3])])
 
                     else:
                         break


### PR DESCRIPTION
- I experienced an error with a bad gpx file, which did not contain any latitude / longitude at a certain time step. 
Therefore made a change on line 98: making sure there are at least 4 elements in the line, before the fourth element is taken.
- I had some gpx files with the extension .GPX (upper case). Therefore I made a change at line 73, this change makes it possible to select files regardless of the case of the extension.