### PR TITLE
Use time from first track, not from general metadata

### DIFF
--- a/strava_local_heatmap.py
+++ b/strava_local_heatmap.py
@@ -83,7 +83,13 @@ def main(args: Namespace) -> None:
         print('Reading {}'.format(os.path.basename(gpx_file)))
 
         with open(gpx_file, encoding='utf-8') as file:
+            inside_trk = False
             for line in file:
+                # don't use time from metadata but form the first trackpoint
+                if not inside_trk:
+                    if '<trk' in line:
+                        inside_trk = True
+                    continue    # continue even if trk was found since there is no more data to be parsed (but only works if the file is multiline)
                 if '<time' in line:
                     l = line.split('>')[1][:4]
 


### PR DESCRIPTION
The script is great! I have been looking for something for quite some time.

Mostly I would like to use it with the GPX files from [BikeCitizens](https://www.bikecitizens.net/). Some of their GPX files contain wrong time data in the metadata tag. Thus it would be better to use the time from the first track. This also shouldn't do any harm to the processing of strava GPX files.